### PR TITLE
Update main TOC MD formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ A curated list of awesome machine learning frameworks and algorithms that work o
     - [Differentiable Interpreters](#differentiable-interpreters)
     - [Binary Data Modelling](#binary-data-modelling)
     - [Soft Clustering Using T-mixture Models](#t-mixture-models)
-
 - [Posts](#posts)
 - [Talks](#talks)
 - [Software](#software)


### PR DESCRIPTION
Fix md formating to Remove extra space between list elements in TOC, so it easier to read.

## Before
<img width="395" alt="TOC before this PR" src="https://user-images.githubusercontent.com/5582506/37563633-09ddf36e-2ac0-11e8-802b-7b6553b340f1.png">


## After
<img width="429" alt="TOC after this PR" src="https://user-images.githubusercontent.com/5582506/37563634-0e2abd9e-2ac0-11e8-8df6-57b3e3cdcfe0.png">
