### PR TITLE
Add 'GitHub JavaScript Dump October 2016' dataset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ A curated list of awesome research papers, datasets and software projects devote
 * [150k JavaScript Dataset](http://www.srl.inf.ethz.ch/js150.php) - Dataset consisting of 150,000 JavaScript files and their parsed ASTs.
 * [card2code](https://github.com/deepmind/card2code) - This dataset contains the language to code datasets described in the paper [Latent Predictor Networks for Code Generation](https://arxiv.org/abs/1603.06744).
 * [NL2Bash](https://github.com/TellinaTool/nl2bash) - This dataset contains a set of ~10,000 bash one-liners collected from websites such as StackOverflow and their English descriptions written by Bash programmers, as described in the [paper](https://arxiv.org/abs/1802.08979).
+ - [GitHub JavaScript Dump October 2016] - Dataset consisting of 494,352 syntactically-valid JavaScript files obtained from the top ~10000 starred JavaScript repositories on GitHub, with licenses, and parsed ASTs.
 
 ## Credits
 


### PR DESCRIPTION
Consists of 492,695 syntactically-valid JavaScript files, their parsed ASTs, and a license identifier for each source repository.

I collected this dataset for a paper that never was (and a previous version of the "Syntax and Sensibility" paper.)