### PR TITLE
Fix #104: Add MASES 2018 to the conference list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A curated list of awesome research papers, datasets and software projects devote
     * [Talks](https://www.youtube.com/playlist?list=PLzTDea_cM27LVPSTdK9RypSyqBHZWPywt)
 * <img src="badges/origin-academia-blue.svg" alt="origin-academia" align="top"> [CamAIML](https://www.microsoft.com/en-us/research/event/artificial-intelligence-and-machine-learning-in-cambridge-2017)
     * [Learning to Code: Machine Learning for Program Induction](https://www.youtube.com/watch?v=vzDuVhFMB9Q) - Alexander Gaunt.
+* <img src="badges/origin-academia-blue.svg" alt="origin-academia" align="top"> [MASES 2018](https://mases18.github.io/)
 
 ## Competitions
 


### PR DESCRIPTION
This PR adds MASES to the list of conferences as per #104 :smile: 	