### PR TITLE
Add DVC (Data Science Version Ctrl) to the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Code Vectors: Understanding Programs Through Embedded Abstracted Symbolic Traces
 * [DeepBugs](https://github.com/michaelpradel/DeepBugs) - Framework for learning bug detectors from an existing code corpus.
 * [DeepSim](https://github.com/parasol-aser/deepsim) - a deep learning-based approach to measure code functional similarity.
 * [rnn-autocomplete](https://github.com/ZeRoGerc/rnn-autocomplete) - Neural code autocompletion with RNN (bachelor's thesis).
+* [DVC](https://dvc.org) - Data Science Version Control - an open-source version control system and pipelines for machine learning models and data sets. It helps tracking, sharing ML projects and reproducing results.
 
 
 #### Utilities


### PR DESCRIPTION
DVC has a good traction - 1300 github starts, strong contributors and users community. Versioning of data sets and models is a real pain and DVC provides a good start for that.