### PR TITLE
Add source{d} models to utils section

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Code Vectors: Understanding Programs Through Embedded Abstracted Symbolic Traces
 * [kmcuda](https://github.com/src-d/kmcuda) - k-means on CUDA to cluster and to search for nearest neighbors in dense space.
 * [wmd-relax](https://github.com/src-d/wmd-relax) - Python package which finds nearest neighbors at Word Mover's Distance.
 * [Tregex, Tsurgeon and Semgrex](https://nlp.stanford.edu/software/tregex.shtml) - Tregex is a utility for matching patterns in trees, based on tree relationships and regular expression matches on nodes (the name is short for "tree regular expressions").
+* [source{d} models](https://github.com/src-d/models) - Machine Learning models for MLonCode trained using the source{d} stack.
 
 #### Datasets
 


### PR DESCRIPTION
Fixes #9.

- [x] This addition is about Machine Learning __on Code__ specifically. General links should be added to [Awesome Machine Learning](https://github.com/josephmisiti/awesome-machine-learning) instead.
- [x] I have checked that the proposed addition is not already in the awesome list.
- [x] I have signed-off my commits as detailed [here](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md).
- [x] The links follow the link template:

        * [Title](URL) - Description.
    or

        * [Title](URL) - Description [Code](link to code).
- [x] The addition is correctly classified as a paper, blog post, talk, software or dataset.
- [x] The commit message must start with a verb (`Add …`, `Deprecate …`) and end without a dot. For exemple:

        Deprecate Theano software
