### PR TITLE
Adding ladder network code pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Code Vectors: Understanding Programs Through Embedded Abstracted Symbolic Traces
 * [DeepBugs](https://github.com/michaelpradel/DeepBugs) - Framework for learning bug detectors from an existing code corpus.
 * [DeepSim](https://github.com/parasol-aser/deepsim) - a deep learning-based approach to measure code functional similarity.
 * [rnn-autocomplete](https://github.com/ZeRoGerc/rnn-autocomplete) - Neural code autocompletion with RNN (bachelor's thesis).
-
+* [Ladder Network](https://github.com/divamgupta/ladder_network_keras) - Keras Implementation of Ladder Network for Semi-Supervised Learning.
 
 #### Utilities
 


### PR DESCRIPTION
The model achieves 98% test accuracy on MNIST with just 100 labeled examples.

Please fill the `[ ]` with an `x` to make sure that you read and followed the checklist

- [x] This addition is about Machine Learning __on Code__ specifically. General links should be added to [Awesome Machine Learning](https://github.com/josephmisiti/awesome-machine-learning) instead.
- [x] I have checked that the proposed addition is not already in the awesome list.
- [x] I have signed-off my commits as detailed [here](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md).
- [x] The links follow the link template:

        * [Title](URL) - Description.
    or

        * [Title](URL) - Description [Code](link to code).
- [x] The addition is correctly classified as a paper, blog post, talk, software or dataset.
- [x] The commit message must start with a verb (`Add …`, `Deprecate …`) and end without a dot. For exemple:

        Deprecate Theano software
